### PR TITLE
TS6 oppgradering ->  skills

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,20 +2,19 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "allowJs": false,
-    "baseUrl": "src",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "lib": [
       "es2022"
     ],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "module": "CommonJS",
     "rootDir": "./src",
     "outDir": "./dist",
-    "ignoreDeprecations": "6.0",
     "strict": true,
-    "target": "es2022"
+    "target": "es2022",
+    "types": ["node"]
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
Ble oppgradert til TS6 18.05, men kjører skills for fullstendig oppgradering.